### PR TITLE
Add dialog result to RepositoryReviewBusinessHandler

### DIFF
--- a/main/plugins/org.talend.designer.core.swt/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/ui/AbsSchemaSWTControllerUI.java
+++ b/main/plugins/org.talend.designer.core.swt/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/ui/AbsSchemaSWTControllerUI.java
@@ -412,6 +412,7 @@ public abstract class AbsSchemaSWTControllerUI extends AbsRepositorySWTControlle
     public ModelSelectionBusinessHandler openModelSelectionDialog(ModelSelectionBusinessHandler handler) {
         ModelSelectionDialog modelSelect = new ModelSelectionDialog(handler, composite.getShell());
         int open = modelSelect.open();
+        handler.setOptionValue(modelSelect.getOptionValue());
         handler.setOpenResult(open);
         return handler;
     }

--- a/main/plugins/org.talend.designer.core.swt/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/ui/AbsSchemaSWTControllerUI.java
+++ b/main/plugins/org.talend.designer.core.swt/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/ui/AbsSchemaSWTControllerUI.java
@@ -436,6 +436,7 @@ public abstract class AbsSchemaSWTControllerUI extends AbsRepositorySWTControlle
     public RepositoryReviewBusinessHandler openRepositoryReviewDialog(RepositoryReviewBusinessHandler handler) {
         RepositoryReviewDialog dialog = new RepositoryReviewDialog(handler, composite.getShell());
         int open = dialog.open();
+        handler.setResult(dialog.getResult());
         handler.setOpenResult(open);
         return handler;
     }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
You cannot assign a repository schema or view a repository schema assigned to a component. 

**What is the new behavior?**
- [x] you can assign the repository schema to a component
- [x] you can view the repository schema assigned to a component



**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
